### PR TITLE
When calculating next cron firing: make sure day of week gets recalculated when skipping ahead a month

### DIFF
--- a/Cron.h
+++ b/Cron.h
@@ -85,6 +85,7 @@ namespace Bosma {
               next.tm_mday = 1;
               next.tm_hour = 0;
               next.tm_min = 0;
+              add(next, std::chrono::seconds(0));
               continue;
             }
             if (day != -1 && next.tm_mday != day) {


### PR DESCRIPTION
Bugfix for the following situation: 

Today is Friday March 6th 2020 (day_of_week 5)
Cron = * * * 11 5
When requesting next firing, the calculation returns:
Sun Nov  1 00:00:00 2020
instead of 
Fri Nov  6 00:00:00 2020

The reason is because when skipping ahead a few months to reach November, while the day of the month is set to 1 and hour and minute to 0, the current day of the week is left as is. This bug manifests itself when "today's" day of week is the same as the day of week in the requested cron. As the day of week is never updated, it thinks the first of November is day of week 5 (Friday) instead of 0 (Sunday)

Fix: call the add() function for 0 seconds, so that std::mktime() gets called, which recalculates tm_wday in the 'next' variable.
